### PR TITLE
Fixed plugin not being migrated.

### DIFF
--- a/OctoberPluginTestCase.php
+++ b/OctoberPluginTestCase.php
@@ -124,7 +124,7 @@ abstract class OctoberPluginTestCase extends Illuminate\Foundation\Testing\TestC
         $this->migrateOctober();
 
         \System\Classes\PluginManager::instance()->loadPlugin(
-            $code,
+            $namespace,
             $path
         );
 


### PR DESCRIPTION
It now passes the correct parameter to `PluginManager::loadPlugin()`.
